### PR TITLE
ci: restrict Codecov workflow permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   CodeCov:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 问题

CodeQL `actions/missing-workflow-permissions` 指出 Codecov 工作流未显式限制 `GITHUB_TOKEN` 权限，可能继承仓库级默认的读写权限。

## 修改

- 在工作流顶层声明 `permissions`
- 仅保留检出代码所需的 `contents: read`
- Codecov 上传仍使用独立的 `CODECOV_TOKEN`，不需要扩大 `GITHUB_TOKEN` 权限

## 验证

- 变更仅涉及 `.github/workflows/codecov.yml`
- 相对 `main` 为 1 个提交、3 行新增、无删除
- 工作流现符合最小权限原则并消除该 CodeQL 风险提示