### PR TITLE
docs: update documentation for v2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Nginx configuration formatter ~10MB size, support CLI, WebUI, x86, ARM, Linux, m
 
 <img src=".github/preview.png">
 
+> **What's new in [v2.3.0](https://github.com/soulteary/nginx-formatter/releases/tag/v2.3.0)**
+>
+> - Updated the automated Go Report Card workflow to use `soulteary/goreportcard-action` v1.1.0.
+> - Hardened the Codecov workflow by restricting `GITHUB_TOKEN` to read-only repository contents.
+> - Published checksums and prebuilt binaries for macOS and Linux on x86, x86-64, ARM64, ARMv6, and ARMv7.
+>
 > **What's new in v2.2.0**
 >
 > - Redesigned the CLI with semantic subcommands (`format` / `serve` / `version`) built on [Cobra](https://github.com/spf13/cobra), with modern `--long`/`-short` flags and per-command `--help`.
@@ -40,7 +46,7 @@ If you use docker, you can use the following command ([DockerHub](https://hub.do
 
 ```bash
 docker pull soulteary/nginx-formatter:latest
-docker pull soulteary/nginx-formatter:v2.2.0
+docker pull soulteary/nginx-formatter:v2.3.0
 ```
 
 ### Homebrew

--- a/README_CN.md
+++ b/README_CN.md
@@ -12,6 +12,12 @@
 
 <img src=".github/preview.png">
 
+> **[v2.3.0](https://github.com/soulteary/nginx-formatter/releases/tag/v2.3.0) 更新说明**
+>
+> - 将自动化 Go Report Card 工作流升级至 `soulteary/goreportcard-action` v1.1.0。
+> - 收紧 Codecov 工作流权限，将 `GITHUB_TOKEN` 明确限制为仅可读取仓库内容。
+> - 发布适用于 macOS 与 Linux 的 x86、x86-64、ARM64、ARMv6、ARMv7 预编译程序及校验和。
+>
 > **v2.2.0 更新说明**
 >
 > - 基于 [Cobra](https://github.com/spf13/cobra) 重新设计命令行，改为语义化子命令（`format` / `serve` / `version`），采用现代的 `--long`/`-short` 参数风格，并为每个命令提供独立的 `--help`。
@@ -40,7 +46,7 @@
 
 ```bash
 docker pull soulteary/nginx-formatter:latest
-docker pull soulteary/nginx-formatter:v2.2.0
+docker pull soulteary/nginx-formatter:v2.3.0
 ```
 
 ### Homebrew 安装


### PR DESCRIPTION
## Summary

- add the v2.3.0 release notes to the English and Chinese READMEs
- update the pinned Docker image example from `v2.2.0` to `v2.3.0`
- link the new release notes directly to the v2.3.0 release page
- preserve the historical “since v2.2.0” CLI compatibility documentation

## Verification

- confirmed v2.3.0 is the latest non-prerelease release
- confirmed release assets include checksums and prebuilt binaries for macOS and Linux
- confirmed no stale pinned `v2.2.0` Docker example remains in either README
- documentation-only change; no runtime behavior is modified